### PR TITLE
Changes to get it working

### DIFF
--- a/lib/containers/AccordionItem/index.js
+++ b/lib/containers/AccordionItem/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-function AccordionItem({header, content}) {
+function AccordionItem({header, children}) {
 
 const [ isActive, toggleActive ] = useState(false);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,11 +27,7 @@ module.exports =  {
       }
     ]
   },
-  resolve: {
-    alias: {
-        react: path.resolve('./node_modules/react'),
-        'react-dom': path.resolve('./node_modules/react-dom')
-      }
-    },
-
+  externals: {
+    react: 'react'
+  }
 };


### PR DESCRIPTION
Hi @sethandleah. 

Regarding facebook/react#15315

I was able to get this working with the following steps. I hope this helps in resolving the issue on your side.

- Remove `react` from the lib bundle by specifying it as external in `webpack.config.js`. 
- Fix `children` reference, replace unused `content`

#### Steps to reproduce

- clone `sethandleah/react-lib`
- clone `sethandleah/myapp`
- `cd myapp`
- `npm i`
- `cd ../react-lib`
- `npm install`
- `npm link ../myapp/node_modules/react` - **important step**
- `npm run build` - **important step**
- `npm link`
- `cd ../myapp`
- `npm link react-lib`
- `npm start`

#### To see the above, do the following:

##### Uncomment these lines at `myapp/src/App.js`:
```js
import Accordion from './Accordion';
import AccordionItem from './AccordionItem';
```
##### The comment out these line, at `myapp/src/App.js`:
```js
import { Accordion } from 'react-lib';
import { AccordionItem } from 'react-lib';
```
